### PR TITLE
Fix Undefined variable: responseHeaderMetadata

### DIFF
--- a/src/MarketplaceWebService/Client.php
+++ b/src/MarketplaceWebService/Client.php
@@ -977,7 +977,7 @@ class MarketplaceWebService_Client implements MarketplaceWebService_Interface
     /**
      * Look for additional error strings in the response and return formatted exception.
      */
-    private function reportAnyErrors($responseBody, $status, Exception $e = null, $metadata)
+    private function reportAnyErrors($responseBody, $status, Exception $e = null, $responseHeaderMetadata)
     {
         $exProps = array();
         $exProps['StatusCode'] = $status;


### PR DESCRIPTION
Correct the $metadata variable name at reportAnyErrors function arg 3.
reportAnyErrors($responseBody, $status, Exception $e = null, $metadata)
In the function there was an undefined variable ($responseHeaderMetadata).
